### PR TITLE
Remove unnecessary Docker Compose monitoring for / from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,15 +34,3 @@ updates:
     labels:
       - "dependencies"
       - "docker"
-
-  # Monitor Docker Compose
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:00"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "docker"


### PR DESCRIPTION
Removed Docker Compose monitoring configuration from Dependabot.