### PR TITLE
fix: only redirect to initial setup when we actually know users are absent

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -306,7 +306,8 @@ def before_request():
         load_user_from_session()
         return
     
-    # Check if initial setup is complete (any active user with password exists)
+    # Check if initial setup is complete (any active user with password exists).
+    has_users = None
     db = SessionLocal()
     try:
       try:
@@ -318,39 +319,35 @@ def before_request():
         # During /api/database resets, tables are briefly absent while Alembic
         # recreates the schema. Let reset/restore routes continue so their own
         # locking and wait logic can finish the operation.
+        # IMPORTANT: do NOT treat a transient DB disconnect as "setup not done";
+        # we only redirect to initial setup when we actually know there are no users.
         logger.info(f"Setup check skipped during transient database reset: {error}")
-
         if request.path.startswith('/api/database'):
           load_user_from_session()
           return
 
-        if request.path.startswith('/api/'):
-          return jsonify({
-            'success': False,
-            'message': 'Initial setup required',
-            'redirect': '/setup.html'
-          }), 503
-
-        if request.path != '/setup.html':
-          from flask import redirect
-          return redirect('/setup.html', code=302)
-        return
-        
-        if not has_users:
-            # Redirect to setup page for HTML requests
-            if not request.path.startswith('/api/'):
-                if request.path != '/setup.html':
-                    from flask import redirect
-                    return redirect('/setup.html', code=302)
-            # For API requests, return a specific error
-            else:
-                return jsonify({
-                    'success': False,
-                    'message': 'Initial setup required',
-                    'redirect': '/setup.html'
-                }), 503
+        if has_users is None:
+            return jsonify({
+                'success': False,
+                'message': 'Service temporarily unavailable',
+                'redirect': None,
+            }), 503
     finally:
         db.close()
+
+    if has_users is False:
+        # Redirect to setup page for HTML requests
+        if not request.path.startswith('/api/'):
+            if request.path != '/setup.html':
+                from flask import redirect
+                return redirect('/setup.html', code=302)
+        # For API requests, return a specific error
+        else:
+            return jsonify({
+                'success': False,
+                'message': 'Initial setup required',
+                'redirect': '/setup.html'
+            }), 503
     
     load_user_from_session()
 


### PR DESCRIPTION
Issue #463

When the DB experiences a transient disconnect, AFT previously responded with 'Initial setup required' and redirected the user to /setup.html. That's incorrect: setup should only be triggered when the check genuinely confirms there are no users, not when we simply can't run the query.

Change
- server/app.py: track the query outcome via has_users = None.
  On ProgrammingError/OperationalError, log and, for non-/api/database routes, return a generic 503 'Service temporarily unavailable' instead of lying with 'Initial setup required'.

Why
- Real first-run: lead users to /setup.html as before.
- DB outage: return a clear service-unavailable response instead of silently kicking everyone into setup, which is what issue #463 is about.

Verification
- python3 -m py_compile server/app.py passes.
- The logic path still allows /api/database routes through during schema resets, preserving the existing behavior for restores/backfills.